### PR TITLE
Move apiregistration.k8s.io/v1beta1 -> apiregistration.k8s.io/v1 for …

### DIFF
--- a/kubernetes/cray-metrics-server/Chart.yaml
+++ b/kubernetes/cray-metrics-server/Chart.yaml
@@ -2,7 +2,7 @@
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 apiVersion: v2
-version: 0.4.0
+version: 0.4.1
 name: cray-metrics-server
 description: Container resource metrics for k8s built-in autoscaling pipelines
 keywords:

--- a/kubernetes/cray-metrics-server/templates/apiservice.yaml
+++ b/kubernetes/cray-metrics-server/templates/apiservice.yaml
@@ -2,7 +2,7 @@
 Copyright 2020 Hewlett Packard Enterprise Development LP
 */ -}}
 ---
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io


### PR DESCRIPTION
…1.22

## Summary and Scope

Update cray-metrics-server to not use removed beta apis in 1.22. Can work on any k8s back to about 1.16. Technically backwards compatible.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6264](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6264)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Mug and Caleb. 

### Tested on:

  * mug
  * Local development environment
  * Virtual Shasta Caleb

### Test description:

Updated existing helm deployment on mug to validate it was fine. Also installed this onto Caleb.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? n/a
- Were continuous integration tests run? If not, why? n/a
- Was upgrade tested? If not, why? n/a
- Was downgrade tested? If not, why? n/a
- Were new tests (or test issues/Jiras) created for this change? n/a

## Risks and Mitigations

Technically k8s already does this for us but as the beta api is removed in 1.22 we have to update.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

